### PR TITLE
OCI credentials storage: only store "auth" field (#2227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.4.x
 
+- Fix problem where credentials locally stored with `registry login` command
+  were not usable in some execution flows. Run `registry login` again with
+  latest version to ensure credentials are stored correctly.
+
 ## Changes for v1.3.x
 
 - Make 'apptainer build' work with signed Docker containers.

--- a/e2e/registry/registry.go
+++ b/e2e/registry/registry.go
@@ -361,7 +361,7 @@ func (c ctx) registryIssue2226(t *testing.T) {
 	}
 
 	u := e2e.CurrentUser(t)
-	configPath := filepath.Join(u.Dir, ".singularity", syfs.DockerConfFile)
+	configPath := filepath.Join(u.Dir, ".apptainer", syfs.DockerConfFile)
 	sourceCtx.AuthFilePath = configPath
 	destCtx.AuthFilePath = configPath
 

--- a/e2e/registry/registry.go
+++ b/e2e/registry/registry.go
@@ -11,13 +11,23 @@
 package registry
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
+	"github.com/apptainer/apptainer/pkg/syfs"
+	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/types"
 )
 
 type ctx struct {
@@ -278,6 +288,130 @@ func (c ctx) registryLoginRepeated(t *testing.T) {
 	}
 }
 
+// JSON files created by our `remote login` flow should be usable in execution
+// flows that use containers/image APIs.
+// See https://github.com/sylabs/singularity/issues/2226
+func (c ctx) registryIssue2226(t *testing.T) {
+	testRegistry := c.env.TestRegistry
+	testRegistryURI := fmt.Sprintf("docker://%s", testRegistry)
+	privRepo := fmt.Sprintf("%s/private/e2eprivrepo", testRegistry)
+	privRepoURI := fmt.Sprintf("docker://%s", privRepo)
+
+	tmpdir, tmpdirCleanup := e2e.MakeTempDir(t, "", "issue2226", "")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			tmpdirCleanup(t)
+		}
+	})
+
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get current working directory: %s", err)
+	}
+	defer os.Chdir(prevCwd)
+	if err = os.Chdir(tmpdir); err != nil {
+		t.Fatalf("could not change cwd to %q: %s", tmpdir, err)
+	}
+
+	areWeLoggedIn := false
+
+	privRepoLogin := func() {
+		c.env.RunApptainer(
+			t,
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("registry login"),
+			e2e.WithArgs("-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, testRegistryURI),
+			e2e.ExpectExit(0),
+		)
+		areWeLoggedIn = true
+	}
+	privRepoLogout := func() {
+		c.env.RunApptainer(
+			t,
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("registry logout"),
+			e2e.WithArgs(testRegistryURI),
+			e2e.ExpectExit(0),
+		)
+		areWeLoggedIn = false
+	}
+
+	privRepoLogin()
+	t.Cleanup(func() {
+		if areWeLoggedIn {
+			privRepoLogout()
+		}
+	})
+
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	policyCtx, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		t.Fatalf("failed to create new policy context: %v", err)
+	}
+
+	sourceCtx := &types.SystemContext{
+		OCIInsecureSkipTLSVerify:    false,
+		DockerInsecureSkipTLSVerify: types.NewOptionalBool(false),
+		DockerRegistryUserAgent:     useragent.Value(),
+	}
+	destCtx := &types.SystemContext{
+		OCIInsecureSkipTLSVerify:    true,
+		DockerInsecureSkipTLSVerify: types.NewOptionalBool(true),
+		DockerRegistryUserAgent:     useragent.Value(),
+	}
+
+	u := e2e.CurrentUser(t)
+	configPath := filepath.Join(u.Dir, ".singularity", syfs.DockerConfFile)
+	sourceCtx.AuthFilePath = configPath
+	destCtx.AuthFilePath = configPath
+
+	source := "docker://alpine:latest"
+	dest := fmt.Sprintf("%s/my-alpine:latest", privRepoURI)
+	sourceRef, err := docker.ParseReference(strings.TrimPrefix(source, "docker:"))
+	if err != nil {
+		t.Fatalf("failed to parse %s reference: %s", source, err)
+	}
+	destRef, err := docker.ParseReference(strings.TrimPrefix(dest, "docker:"))
+	if err != nil {
+		t.Fatalf("failed to parse %s reference: %s", dest, err)
+	}
+
+	_, err = copy.Image(context.Background(), policyCtx, destRef, sourceRef, &copy.Options{
+		ReportWriter:   io.Discard,
+		SourceCtx:      sourceCtx,
+		DestinationCtx: destCtx,
+	})
+	if err != nil {
+		var e docker.ErrUnauthorizedForCredentials
+		if errors.As(err, &e) {
+			t.Fatalf("Authentication info written by 'registry login' did not work when trying to copy OCI image to private repo (%v)", e)
+		}
+		t.Fatalf("Failed to copy %s to %s: %s", source, dest, err)
+	}
+
+	privRepoLogout()
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("noauth"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull --no-https"),
+		e2e.WithArgs(dest),
+		e2e.ExpectExit(255),
+	)
+
+	privRepoLogin()
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("auth"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull --no-https"),
+		e2e.WithArgs(dest),
+		e2e.ExpectExit(0),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
@@ -292,5 +426,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"registry login push private": np(c.registryLoginPushPrivate),
 		"registry login repeated":     np(c.registryLoginRepeated),
 		"registry list":               np(c.registryList),
+		"registry issue 2226":         np(c.registryIssue2226),
 	}
 }


### PR DESCRIPTION
* chg storage of OCI credentials to only store "auth" field

* chgd auth storage mechanism to use higher-level docker/cli APIs

* added e2e test

* add CHANGELOG entry

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
